### PR TITLE
Add superscript to supportedFormat in body.json

### DIFF
--- a/default/km/field/body.json
+++ b/default/km/field/body.json
@@ -13,7 +13,8 @@
         "HYPERLINK",
         "ITALICS",
         "NUMBERED_LIST",
-        "UNDERLINE"
+        "UNDERLINE",
+        "SUPERSCRIPT"
       ]
     }
   },


### PR DESCRIPTION
This change adds SUPERSCRIPT to the supported formats so that the apply succeeds.